### PR TITLE
Accept v1 and v2 cast hashes

### DIFF
--- a/src/pages/api/search.js
+++ b/src/pages/api/search.js
@@ -32,7 +32,9 @@ export async function searchCasts(query) {
     casts = await supabase
       .from('casts')
       .select()
-      .or(`hash.ilike.${merkleRoot},parent_hash.ilike.${merkleRoot}`)
+      .or(
+        `hash.ilike.${merkleRoot},parent_hash.ilike.${merkleRoot},hash_v1.ilike.${merkleRoot},parent_hash_v1.ilike.${merkleRoot}`
+      )
       .eq('deleted', false)
       .gt('published_at', new Date(after).toISOString())
       .lt('published_at', new Date(before).toISOString())


### PR DESCRIPTION
Warpcast API's are migrating to new hashes, but we don't want all past links to break. Deploy after https://github.com/gskril/farcaster-indexer/pull/14