### PR TITLE
Use full text search in queries

### DIFF
--- a/src/pages/api/search.js
+++ b/src/pages/api/search.js
@@ -164,7 +164,10 @@ export async function searchCasts(query) {
       .from('casts')
       .select('*')
       .ilike('author_username', username ? username : '%')
-      .textSearch('fts', searchTerms)
+      .textSearch('fts', searchTerms, {
+        type: 'phrase',
+        config: 'english',
+      })
       .eq('deleted', false)
       .gt('published_at', new Date(after).toISOString())
       .lt('published_at', new Date(before).toISOString())

--- a/src/pages/api/search.js
+++ b/src/pages/api/search.js
@@ -155,11 +155,16 @@ export async function searchCasts(query) {
         { ascending: orderAscending }
       )
   } else {
+    const searchTerms = textQuery
+      .trim()
+      .replace(/:/g, '\\:') // escape colons with backslash since they're special characters in full text search (':' -> '\:')
+      .split(/\s+/) // split query by any whitespace characters
+      .join(' & ')
     casts = await supabase
       .from('casts')
       .select('*')
       .ilike('author_username', username ? username : '%')
-      .ilike('text', textQuery ? `%${textQuery}%` : '%')
+      .textSearch('fts', searchTerms)
       .eq('deleted', false)
       .gt('published_at', new Date(after).toISOString())
       .lt('published_at', new Date(before).toISOString())


### PR DESCRIPTION
After https://github.com/gskril/farcaster-indexer/pull/20 lands and the database is updated, we should update the queries to take advantage of full text search. 

I think this would address issues raised in https://github.com/gskril/searchcaster/issues/19. But I don't think FTS supports backticks, so I wasn't able to reproduce https://github.com/gskril/searchcaster/issues/22.

https://user-images.githubusercontent.com/32348009/233812488-5dc98dfd-d629-42b3-9b91-533193fdda7b.mov

